### PR TITLE
빈후처리기를 이용한 자동 프록시 - 486p

### DIFF
--- a/src/main/java/chap1/springbook/user/service/NameMatchClassMethodPointcut.java
+++ b/src/main/java/chap1/springbook/user/service/NameMatchClassMethodPointcut.java
@@ -1,0 +1,26 @@
+package chap1.springbook.user.service;
+
+import org.springframework.aop.ClassFilter;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.util.PatternMatchUtils;
+
+/**
+ * Created by kd4 on 2016. 2. 29..
+ */
+public class NameMatchClassMethodPointcut extends NameMatchMethodPointcut {
+    public void setMappedClassName(String mappedClassName){
+        this.setClassFilter(new SimpleClassFilter(mappedClassName));
+    }
+
+    static class SimpleClassFilter implements ClassFilter{
+        String mappedName;
+
+        private SimpleClassFilter(String mappedName){
+            this.mappedName = mappedName;
+        }
+
+        public boolean matches(Class<?> clazz){
+            return PatternMatchUtils.simpleMatch(mappedName,clazz.getSimpleName());
+        }
+    }
+}

--- a/src/main/resources/spring-config.xml
+++ b/src/main/resources/spring-config.xml
@@ -24,16 +24,20 @@
     </bean>
 
 
-    <bean id="userServiceImpl" class="chap1.springbook.user.service.UserServiceImpl">
+    <bean id="userService" class="chap1.springbook.user.service.UserServiceImpl">
         <property name="userDao" ref="userDao"></property>
         <property name="userLevelUpgradePolicy" ref="userLevelUpgradePolicy"></property>
+    </bean>
+
+    <bean id="testUserService" class="chap1.springbook.user.UserServiceTest$TestUserServiceImpl" parent="userService">
     </bean>
 
     <bean id="transactionAdvice" class="chap1.springbook.user.service.TransactionAdvice">
         <property name="transactionManager" ref="transactionManager"></property>
     </bean>
 
-    <bean id="transactionPointcut" class="org.springframework.aop.support.NameMatchMethodPointcut">
+    <bean id="transactionPointcut" class="chap1.springbook.user.service.NameMatchClassMethodPointcut">
+        <property name="mappedClassName" value="*ServiceImpl"/>
         <property name="mappedName" value="upgrade*"/>
     </bean>
 
@@ -42,14 +46,5 @@
         <property name="pointcut" ref="transactionPointcut"/>
     </bean>
 
-    <bean id="userService" class="org.springframework.aop.framework.ProxyFactoryBean">
-        <property name="target" ref="userServiceImpl"/>
-        <property name="interceptorNames">
-            <list>
-                <value>transactionAdvisor</value>
-            </list>
-        </property>
-    </bean>
-
-
+    <bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"></bean>
 </beans>

--- a/src/test/java/chap1/springbook/user/UserServiceTest.java
+++ b/src/test/java/chap1/springbook/user/UserServiceTest.java
@@ -33,12 +33,8 @@ import static chap1.springbook.user.service.UserLevelUpgradePolicyDefault.MIN_LO
 @ContextConfiguration(locations = "/spring-config.xml")
 public class UserServiceTest {
 
-    static class TestUserService extends UserServiceImpl {
-        private String id;
-
-        private TestUserService(String id) {
-            this.id = id;
-        }
+    static class TestUserServiceImpl extends UserServiceImpl {
+        private static String id = "madnite1"; // 테스트 픽스처의 users(3)의 id값으로 고정시켜버린다
 
         @Override
         protected void upgradeLevel(User user) {
@@ -53,6 +49,9 @@ public class UserServiceTest {
 
     @Autowired
     UserService userService;
+
+    @Autowired
+    UserService testUserService;
 
     @Autowired
     UserDao userDao;
@@ -136,20 +135,12 @@ public class UserServiceTest {
     @DirtiesContext // 컨텍스트 무효화 애노테이션
     public void upgradeAllOrNothing() throws Exception {
 
-        TestUserService testUserService = new TestUserService(users.get(3).getId());
-        testUserService.setUserDao(this.userDao);
-        testUserService.setUserLevelUpgradePolicy(this.userLevelUpgradePolicy);
-
-        ProxyFactoryBean txProxyFactoryBean = context.getBean("&userService", ProxyFactoryBean.class);
-        txProxyFactoryBean.setTarget(testUserService);
-
-        UserService txUserService = (UserService) txProxyFactoryBean.getObject();
         userDao.deleteAll();
 
         for (User user : users) userDao.add(user);
 
         try {
-            txUserService.upgradeLevels();
+            testUserService.upgradeLevels();
             Assert.fail("TestUserServiceException expected");
         } catch (TestUserServiceException e) {
 


### PR DESCRIPTION
스프링에서는 빈 생성 후에 작업을 정의할 수 있도록 빈 후처리기 기능이 있다. 이를 이용해서 포인터컷과 어드바이스를 빈 생성 시점에 컨트롤할 수 있다.
설정파일을 중복으로 작성하던 문제를 해결하였다.
